### PR TITLE
Fix Class with waitlist displayed with Waitlist only button

### DIFF
--- a/src/syncer/Wrapper.php
+++ b/src/syncer/Wrapper.php
@@ -151,13 +151,13 @@ class Wrapper {
       if ($schedule['reservable'] && $this->config->get('enable_capacity_in_full_syncer')) {
         $availabilityStatus = 'class full';
         $availability = $schedule["capacity"] - $schedule["booked"];
-        if ($availability > 0) {
-          $availabilityStatus = $availability . ' spots left';
-        }
         $waitlist = $schedule["waitlistCapacity"] - $schedule["waitlistBooked"];
         if ($waitlist > 0) {
           // @todo disaplay waitlist availability.
           $availabilityStatus = 'waitlist only';
+        }
+        if ($availability > 0) {
+          $availabilityStatus = $availability . ' spots left';
         }
         $schedule['availabilityStatus'] = $availabilityStatus;
       }


### PR DESCRIPTION
# How to review

- run `drush yn-sync -vv openy_daxko_gxp_syncer.qsyncer ` you should see normal work syncer
- run `drush -vv queue-run openy_daxko_gxp `, go to schedules you should see that schedules with waitlist now display with register button if have open spots
![image](https://user-images.githubusercontent.com/26228931/114504740-015e7000-9c38-11eb-82cb-bd677a04f8f9.png)
