### PR TITLE
[RGTC-1662] Add openy_mappings_feature module as dependency

### DIFF
--- a/openy_daxko_gxp_syncer.info.yml
+++ b/openy_daxko_gxp_syncer.info.yml
@@ -9,3 +9,4 @@ dependencies:
   - openy_system
   - openy_node_session
   - ymca_sync:ymca_sync
+  - openy_mappings_feature


### PR DESCRIPTION
## Motivation
openy_daxko_gxp_syncer have have links in code to location type in openy_mappings - module openy_mappings_feature create this type on install