### PR TITLE
#7 - fixed the menu item for the settings form

### DIFF
--- a/openy_daxko_gxp_syncer.info.yml
+++ b/openy_daxko_gxp_syncer.info.yml
@@ -9,3 +9,4 @@ dependencies:
   - openy_system
   - openy_node_session
   - ymca_sync:ymca_sync
+  - groupexpro

--- a/openy_daxko_gxp_syncer.links.menu.yml
+++ b/openy_daxko_gxp_syncer.links.menu.yml
@@ -1,5 +1,5 @@
 openy_daxko_gxp_syncer.settings:
   title: 'GroupEx Pro Daxko API Syncer settings'
-  parent: openy_system.openy_integrations_groupexpro
+  parent: openy_gxp.openy_integrations_groupexpro
   route_name: openy_daxko_gxp_syncer.settings_form
   weight: 130


### PR DESCRIPTION
After this fix we can see the menu link in the admin menu and on the **GroupEx Pro** settings page
![MAINTAIN-160LinkNotPresent](https://user-images.githubusercontent.com/744406/138937712-2d13a38b-5042-4343-8fd0-e2edb72970fd.png)

