### PR TITLE
#7 fixed the parent route for the menu link; added the correct dependency to openy_gxp module

### DIFF
--- a/openy_daxko_gxp_syncer.info.yml
+++ b/openy_daxko_gxp_syncer.info.yml
@@ -9,4 +9,4 @@ dependencies:
   - openy_system
   - openy_node_session
   - ymca_sync:ymca_sync
-  - groupexpro
+  - openy_gxp:openy_gxp


### PR DESCRIPTION
Unfortunately, I made the wrong fix in the previous patch for this issue.
Sorry for that.
This one should be more correct.
