### PR TITLE
fix(ITCR-1136): remove openy_gxp dependency

### DIFF
--- a/openy_daxko_gxp_syncer.info.yml
+++ b/openy_daxko_gxp_syncer.info.yml
@@ -8,4 +8,3 @@ dependencies:
   - openy_system
   - openy_node_session
   - ymca_sync:ymca_sync
-  - openy_gxp:openy_gxp

--- a/openy_daxko_gxp_syncer.links.menu.yml
+++ b/openy_daxko_gxp_syncer.links.menu.yml
@@ -1,5 +1,5 @@
 openy_daxko_gxp_syncer.settings:
   title: 'GroupEx Pro Daxko API Syncer settings'
-  parent: openy_gxp.openy_integrations_groupexpro
+  parent: openy_system.openy_integrations_daxko
   route_name: openy_daxko_gxp_syncer.settings_form
   weight: 130


### PR DESCRIPTION
## Summary

- Remove `openy_gxp:openy_gxp` from `dependencies` in `openy_daxko_gxp_syncer.info.yml`
- Move menu link parent from `openy_gxp.openy_integrations_groupexpro` to `openy_system.openy_integrations_daxko`

## Context

ITCR-1136 deprecates and auto-uninstalls `openy_gxp`. The module listed `openy_gxp:openy_gxp` as a dependency — when `openy_gxp` was cascade-uninstalled it would take down `openy_daxko_gxp_syncer` (the active Daxko API syncer that must keep running).

**Investigation confirmed** the dependency was only structural, not functional:
- No PHP imports or service calls to `openy_gxp` classes
- The only real coupling was the menu link parent pointing to `openy_gxp.openy_integrations_groupexpro`

## Changes

**`openy_daxko_gxp_syncer.info.yml`** — removed `- openy_gxp:openy_gxp` from dependencies.

**`openy_daxko_gxp_syncer.links.menu.yml`** — parent changed to `openy_system.openy_integrations_daxko`, which is the existing Daxko admin section (already contains `daxko.admin` and `openy_daxko2.admin`). This is the correct location for a Daxko API syncer module.

## Test plan

- [ ] Install module without `openy_gxp` present — module enables successfully
- [ ] Uninstall `openy_gxp` on a site that has `openy_daxko_gxp_syncer` — syncer stays enabled
- [ ] Admin settings link appears under `/admin/openy/integrations/daxko`