### PR TITLE
Fix coding standards and wrong namespace in SettingsForm

### DIFF
--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -3,6 +3,7 @@
 namespace Drupal\openy_daxko_gxp_syncer\Form;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\TypedConfigManagerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
@@ -32,15 +33,17 @@ class SettingsForm extends ConfigFormBase {
   /**
    * Constructor.
    *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The Entity manager.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The factory for configuration objects.
+   * @param \Drupal\Core\Config\TypedConfigManagerInterface $typedConfigManager
+   *   The typed config manager.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The Entity manager.
    * @param \Drupal\openy_mappings\LocationMappingRepository $mappingRepository
    *   Location mapping repo.
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, ConfigFactoryInterface $config_factory, LocationMappingRepository $mappingRepository) {
-    parent::__construct($config_factory);
+  public function __construct(ConfigFactoryInterface $config_factory, TypedConfigManagerInterface $typedConfigManager, EntityTypeManagerInterface $entity_type_manager, LocationMappingRepository $mappingRepository) {
+    parent::__construct($config_factory, $typedConfigManager);
     $this->entityTypeManager = $entity_type_manager;
     $this->mappingRepository = $mappingRepository;
   }
@@ -50,11 +53,13 @@ class SettingsForm extends ConfigFormBase {
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('entity_type.manager'),
       $container->get('config.factory'),
+      $container->get('config.typed'),
+      $container->get('entity_type.manager'),
       $container->get('openy_mappings.location_repository')
     );
   }
+
   /**
    * {@inheritdoc}
    */

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -26,7 +26,7 @@ class SettingsForm extends ConfigFormBase {
   /**
    * Mapping repository.
    *
-   * @var \Drupal\ymca_mappings\LocationMappingRepository
+   * @var \Drupal\openy_mappings\LocationMappingRepository
    */
   protected $mappingRepository;
 
@@ -35,15 +35,15 @@ class SettingsForm extends ConfigFormBase {
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The factory for configuration objects.
-   * @param \Drupal\Core\Config\TypedConfigManagerInterface $typedConfigManager
+   * @param \Drupal\Core\Config\TypedConfigManagerInterface $typed_config_manager
    *   The typed config manager.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The Entity manager.
    * @param \Drupal\openy_mappings\LocationMappingRepository $mappingRepository
    *   Location mapping repo.
    */
-  public function __construct(ConfigFactoryInterface $config_factory, TypedConfigManagerInterface $typedConfigManager, EntityTypeManagerInterface $entity_type_manager, LocationMappingRepository $mappingRepository) {
-    parent::__construct($config_factory, $typedConfigManager);
+  public function __construct(ConfigFactoryInterface $config_factory, TypedConfigManagerInterface $typed_config_manager, EntityTypeManagerInterface $entity_type_manager, LocationMappingRepository $mappingRepository) {
+    parent::__construct($config_factory, $typed_config_manager);
     $this->entityTypeManager = $entity_type_manager;
     $this->mappingRepository = $mappingRepository;
   }


### PR DESCRIPTION
## Summary

Follow-up to #16 — review fixes:

- Fix `@var` namespace `ymca_mappings` → `openy_mappings` for `LocationMappingRepository` property docblock
- Rename `$typedConfigManager` → `$typed_config_manager` in constructor signature and PHPDoc to follow Drupal coding standards (snake_case)

## Test plan

- [ ] Verify the settings form at `/admin/openy/integrations/daxko-gxp/settings` loads without errors
- [ ] Confirm no regressions in form submission